### PR TITLE
added parameter for strix image everywhere it is used

### DIFF
--- a/charts/humio-core/templates/post-install-job-balance.yaml
+++ b/charts/humio-core/templates/post-install-job-balance.yaml
@@ -22,7 +22,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}-post-install
       initContainers:
         - name: wait-for-humio
-          image: humio/strix
+          image: "{{ default "humio/strix" .Values.strixImage }}"
+          imagePullPolicy: {{ .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait
@@ -32,7 +33,8 @@ spec:
           - {{ .Release.Namespace }}
           - "--timeout=1500s"
         - name: wait-for-single-user-token
-          image: humio/strix
+          image: "{{ default "humio/strix" .Values.strixImage }}"
+          imagePullPolicy: {{ .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait
@@ -43,7 +45,8 @@ spec:
           - "--timeout=1500s"
       containers:
       - name: set-default-partitions
-        image: "humio/strix"
+        image: "{{ default "humio/strix" .Values.strixImage }}"
+        imagePullPolicy: {{ .Values.strixImagePullPolicy }}
         command: ["/humio-balance.sh"]
         env:
           - name: HUMIO_BASE_URL

--- a/charts/humio-core/templates/post-install-job-create-single-user-token.yaml
+++ b/charts/humio-core/templates/post-install-job-create-single-user-token.yaml
@@ -22,7 +22,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}-post-install
       initContainers:
         - name: wait-for-humio
-          image: humio/strix
+          image: "{{ default "humio/strix" .Values.strixImage }}"
+          imagePullPolicy: {{ .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait
@@ -33,7 +34,7 @@ spec:
           - "--timeout=1500s"
       containers:
         - name: humio-init
-          image: "{{ .Values.initImage }}"
+          image: "{{ default "humio/strix" .Values.initImage }}"
           imagePullPolicy: {{ .Values.initImagePullPolicy }}
           command: ["/humio-store-developer-token.sh"]
           env:

--- a/charts/humio-core/templates/post-install-job-create-tokens.yaml
+++ b/charts/humio-core/templates/post-install-job-create-tokens.yaml
@@ -24,7 +24,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}-post-install
       initContainers:
         - name: wait-for-humio
-          image: humio/strix
+          image: "{{ default "humio/strix" .Values.strixImage }}"
+          imagePullPolicy: {{ .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait
@@ -34,7 +35,8 @@ spec:
           - {{ .Release.Namespace }}
           - "--timeout=1500s"
         - name: wait-for-single-user-token
-          image: humio/strix
+          image: "{{ default "humio/strix" .Values.strixImage }}"
+          imagePullPolicy: {{ .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait
@@ -45,8 +47,8 @@ spec:
           - "--timeout=1500s"
       containers:
         - name: humio-init
-          image: "{{ .Values.initImage }}"
-          imagePullPolicy: {{ .Values.initImagePullPolicy }}
+          image: "{{ .Values.strixImage }}"
+          imagePullPolicy: {{ .Values.strixImagePullPolicy }}
           command: ["/humio-init.sh"]
           env:
             - name: HUMIO_TOKEN

--- a/charts/humio-core/templates/post-install-job-create-tokens.yaml
+++ b/charts/humio-core/templates/post-install-job-create-tokens.yaml
@@ -47,8 +47,8 @@ spec:
           - "--timeout=1500s"
       containers:
         - name: humio-init
-          image: "{{ .Values.strixImage }}"
-          imagePullPolicy: {{ .Values.strixImagePullPolicy }}
+          image: "{{ .Values.initImage }}"
+          imagePullPolicy: {{ .Values.initImagePullPolicy }}
           command: ["/humio-init.sh"]
           env:
             - name: HUMIO_TOKEN

--- a/charts/humio-core/templates/statefulset.yaml
+++ b/charts/humio-core/templates/statefulset.yaml
@@ -37,7 +37,8 @@ spec:
       {{- if eq .Values.external.kafkaBrokers "" }}
       initContainers:
         - name: wait-for-kafka
-          image: humio/strix
+          image: "{{ default "humio/strix" .Values.strixImage }}"
+          imagePullPolicy: {{ .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait

--- a/charts/humio-core/values.yaml
+++ b/charts/humio-core/values.yaml
@@ -18,6 +18,9 @@ oauthConfig:
   publicUrl: ""
   autoCreateUserOnSuccessfulLogin: true
 
+strixImage: humio/strix:latest
+strixImagePullPolicy: Always
+
 initImage: humio/strix:latest
 initImagePullPolicy: Always
 

--- a/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
@@ -22,7 +22,8 @@ spec:
 {{- if .Values.es.autodiscovery }}
       initContainers:
         - name: wait-for-humio
-          image: humio/strix
+          image: {{ default "humio/strix" .Values.strixImage }}
+          imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait
@@ -35,7 +36,8 @@ spec:
     {{- if .Values.global.sharedTokens }}
       {{- if .Values.global.sharedTokens.fluentbit }}
         - name: wait-for-shared-tokens
-          image: humio/strix
+          image: {{ default "humio/strix" .Values.strixImage }}
+          imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait

--- a/charts/humio-fluentbit/values.yaml
+++ b/charts/humio-fluentbit/values.yaml
@@ -1,4 +1,8 @@
+image: fluent/fluent-bit:1.2.2
 imagePullPolicy: Always
+
+strixImage: humio/strix:latest
+strixImagePullPolicy: Always
 
 es:
   port: 9200

--- a/charts/humio-metrics/templates/post-install-job-create-dashboards.yaml
+++ b/charts/humio-metrics/templates/post-install-job-create-dashboards.yaml
@@ -23,7 +23,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}-post-install
       initContainers:
         - name: wait-for-humio
-          image: humio/strix
+          image: {{ default "humio/strix" .Values.strixImage }}
+          imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait
@@ -33,7 +34,8 @@ spec:
           - {{ .Release.Namespace }}
           - "--timeout=1500s"
         - name: wait-for-repo-to-exist
-          image: humio/strix
+          image: {{ default "humio/strix" .Values.strixImage }}
+          imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait

--- a/charts/humio-metrics/templates/publish-cron-job.yaml
+++ b/charts/humio-metrics/templates/publish-cron-job.yaml
@@ -15,7 +15,8 @@ spec:
           serviceAccountName: {{ .Release.Name }}-post-install
           initContainers:
             - name: wait-for-humio
-              image: humio/strix
+              image: {{ default "humio/strix" .Values.strixImage }}
+              imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
               command:
               - kubectl
               - wait
@@ -25,7 +26,8 @@ spec:
               - {{ .Release.Namespace }}
               - "--timeout=1500s"
             - name: wait-for-repo-to-exist
-              image: humio/strix
+              image: {{ default "humio/strix" .Values.strixImage }}
+              imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
               command:
               - kubectl
               - wait

--- a/charts/humio-metrics/values.yaml
+++ b/charts/humio-metrics/values.yaml
@@ -12,6 +12,9 @@ initImagePullPolicy: Always
 jobImage: humio/strix:latest
 jobImagePullPolicy: Always
 
+strixImage: humio/strix:latest
+strixImagePullPolicy: Always
+
 image: "docker.elastic.co/beats/metricbeat-oss:7.2.0"
 
 publish:

--- a/charts/humio-strix/templates/deployment.yaml
+++ b/charts/humio-strix/templates/deployment.yaml
@@ -27,7 +27,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}-strix
       initContainers:
         - name: wait-for-humio
-          image: humio/strix
+          image: {{ default "humio/strix" .Values.strixImage }}
+          imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait
@@ -41,7 +42,8 @@ spec:
       {{- if .Values.global.sharedTokens.perf }}
       initContainers:
         - name: wait-for-shared-tokens
-          image: humio/strix
+          image: {{ default "humio/strix" .Values.strixImage }}
+          imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
           command:
           - kubectl
           - wait

--- a/charts/humio-strix/values.yaml
+++ b/charts/humio-strix/values.yaml
@@ -41,6 +41,12 @@ perfTime: ""
 image: humio/humio-ingest-load-test:latest
 imagePullPolicy: Always
 
+strixImage: humio/strix
+strixImagePullPolicy: Always
+
+initImage: humio/strix:latest
+initImagePullPolicy: Always
+
 nameOverride: "strix"
 fullnameOverride: "strix"
 


### PR DESCRIPTION
Fixes: #50 

In some charts, the image is already parameterized by "initImage" but not used everywhere.
To not break backwards compatibility I introduce a new parameter everywhere.