### PR TITLE
Added ServiceMonitor/Prometheus Operator support as like in the original fluent-bit package

### DIFF
--- a/charts/humio-fluentbit/templates/fluent-bit-configmap.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-configmap.yaml
@@ -7,6 +7,11 @@ metadata:
     k8s-app: {{ .Release.Name }}
 data:
   fluent-bit-service.conf: {{- toYaml .Values.serviceConfig | indent 2 }}
+{{- if .Values.metrics.enabled }}
+        HTTP_Server  On
+        HTTP_Listen  0.0.0.0
+        HTTP_Port    2020
+{{- end }}
 
   fluent-bit-input.conf: {{- toYaml .Values.inputConfig | indent 2 }}
 

--- a/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
@@ -21,10 +21,6 @@ spec:
         k8s-app: {{ .Release.Name }}
         version: v1
         kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
     spec:
 {{- if .Values.es.autodiscovery }}
       initContainers:

--- a/charts/humio-fluentbit/templates/fluent-bit-service.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-service.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.metrics.service.annotations }}
+  annotations:
+{{ toYaml .Values.metrics.service.annotations | indent 4 }}
+{{- end }}
+  name: {{ template "humio-fluentbit.fullname" . }}-metrics
+  labels:
+    app: {{ template "humio-fluentbit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  {{- if .Values.metrics.service }}
+  {{- range $key, $value := .Values.metrics.service.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type}}
+  sessionAffinity: None
+  ports:
+  - port: {{ .Values.metrics.service.port }}
+    targetPort: metrics
+    name: metrics
+  selector:
+    app: {{ template "humio-fluentbit.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/humio-fluentbit/templates/fluent-bit-servicemonitor.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "humio-fluentbit.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "humio-fluentbit.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      path: /api/v1/metrics/prometheus
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ include "humio-fluentbit.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/humio-fluentbit/values.yaml
+++ b/charts/humio-fluentbit/values.yaml
@@ -19,7 +19,7 @@ tokenSecretName: ""
 tokenSecretKeyName: token
 
 metrics:
-  enabled: true
+  enabled: false
   service:
     # labels:
     #   key: value
@@ -31,7 +31,7 @@ metrics:
     port: 2020
     type: ClusterIP
   serviceMonitor:
-    enabled: true
+    enabled: false
     additionalLabels: {}
     # namespace: monitoring
     # interval: 30s

--- a/charts/humio-fluentbit/values.yaml
+++ b/charts/humio-fluentbit/values.yaml
@@ -18,6 +18,25 @@ fullnameOverride: ""
 tokenSecretName: ""
 tokenSecretKeyName: token
 
+metrics:
+  enabled: true
+  service:
+    # labels:
+    #   key: value
+    annotations: {}
+    # In order for Prometheus to consume metrics automatically use the following annotations:
+    # prometheus.io/path: "/api/v1/metrics/prometheus"
+    # prometheus.io/port: "2020"
+    # prometheus.io/scrape: "true"
+    port: 2020
+    type: ClusterIP
+  serviceMonitor:
+    enabled: true
+    additionalLabels: {}
+    # namespace: monitoring
+    # interval: 30s
+    # scrapeTimeout: 10s
+
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
We are using Prometheus Operator for monitoring all the middleware components (including fluent-bit/humio-fluentbit) therefore we need built in support for ServiceMonitor CRDs as like it was done in the original chart: 
https://github.com/helm/charts/blob/master/stable/fluent-bit/templates/servicemonitor.yaml

This is community wide standard and most of the community driven stable charts provide the functionality.

Changes:

If both the attributes are set to true:
```
metrics:
  enabled: true
    serviceMonitor:
      enabled: true
```

The following new objects are being created:

```
# Source: humio-fluentbit/templates/fluent-bit-servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: RELEASE-NAME-humio-fluentbit
  labels:
    app: humio-fluentbit
    chart: humio-fluentbit-0.1.0
    heritage: Helm
    release: RELEASE-NAME
spec:
  endpoints:
    - port: metrics
      path: /api/v1/metrics/prometheus
  namespaceSelector:
    matchNames:
      - default
  selector:
    matchLabels:
      app: humio-fluentbit
      release: RELEASE-NAME

# Source: humio-fluentbit/templates/fluent-bit-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-humio-fluentbit-metrics
  labels:
    app: humio-fluentbit
    chart: humio-fluentbit-0.1.0
    heritage: Helm
    release: RELEASE-NAME
spec:
  type: ClusterIP
  sessionAffinity: None
  ports:
  - port: 2020
    targetPort: metrics
    name: metrics
  selector:
    app: humio-fluentbit
    release: RELEASE-NAME
```

and fluent-bit config gets extended with:
```
  fluent-bit-service.conf:  |-
    [SERVICE]
        Flush        1
        Daemon       Off
        Log_Level    info
        Parsers_File parsers.conf
        HTTP_Server  On                    # new !!!!
        HTTP_Listen  0.0.0.0              # new !!!!
        HTTP_Port    2020                  # new !!!!
```
