### PR TITLE
Allow tolerations on fluent bit daemonset

### DIFF
--- a/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
@@ -146,7 +146,10 @@ spec:
         configMap:
           name: {{ .Release.Name }}-fluent-bit-config
       serviceAccountName: {{ .Release.Name }}-fluentbit-read
+      {{- with .Values.tolerations }}
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+        {{- toYaml . | nindent 6 }}
+      {{- end }}


### PR DESCRIPTION
Allows tolerations on fluent bit DS. 

The `values.yaml` file for the chart already contains the `tolerations: []` placeholder (https://github.com/humio/humio-helm-charts/blob/master/charts/humio-fluentbit/values.yaml#L130), it just isn't being used.