### PR TITLE
Added node selector for daemon set on helm-fluentbit

### DIFF
--- a/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
@@ -153,3 +153,7 @@ spec:
         effect: NoSchedule
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
`values.yaml` is already expecting the nodeSelector but nothing was happening when assigning a value to it.
https://github.com/humio/humio-helm-charts/blob/master/charts/humio-fluentbit/values.yaml#L129