### PR TITLE
feature(fluent-bit): allow imagePullSecrets to be overriden

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.1"
 description: A Helm chart for Humio Components
 name: humio-helm-charts
-version: 0.8.22
+version: 0.8.23

--- a/charts/humio-fluentbit/Chart.yaml
+++ b/charts/humio-fluentbit/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: humio-fluentbit
-version: 0.1.0
+version: 0.1.1

--- a/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
@@ -49,8 +49,10 @@ spec:
         - name: wait-for-shared-tokens
           image: {{ default "humio/strix" .Values.strixImage }}
           imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
+          {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
           - kubectl
           - wait
@@ -72,8 +74,10 @@ spec:
             path: /api/v1/metrics
             port: 2020
         imagePullPolicy: {{ default "Always" .Values.imagePullPolicy }}
+        {{- with .Values.imagePullSecrets }}
         imagePullSecrets:
           {{- toYaml . | nindent 12 }}
+        {{- end }}
         ports:
           - containerPort: 2020
         env:

--- a/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
@@ -26,15 +26,15 @@ spec:
         prometheus.io/port: "2020"
         prometheus.io/path: /api/v1/metrics/prometheus
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- if .Values.es.autodiscovery }}
       initContainers:
         - name: wait-for-humio
           image: {{ default "humio/strix" .Values.strixImage }}
           imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
-          {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           command:
           - kubectl
           - wait
@@ -49,10 +49,6 @@ spec:
         - name: wait-for-shared-tokens
           image: {{ default "humio/strix" .Values.strixImage }}
           imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
-          {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           command:
           - kubectl
           - wait
@@ -74,10 +70,6 @@ spec:
             path: /api/v1/metrics
             port: 2020
         imagePullPolicy: {{ default "Always" .Values.imagePullPolicy }}
-        {{- with .Values.imagePullSecrets }}
-        imagePullSecrets:
-          {{- toYaml . | nindent 12 }}
-        {{- end }}
         ports:
           - containerPort: 2020
         env:

--- a/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
@@ -49,6 +49,8 @@ spec:
         - name: wait-for-shared-tokens
           image: {{ default "humio/strix" .Values.strixImage }}
           imagePullPolicy: {{ default "Always" .Values.strixImagePullPolicy }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
           command:
           - kubectl
           - wait
@@ -70,6 +72,8 @@ spec:
             path: /api/v1/metrics
             port: 2020
         imagePullPolicy: {{ default "Always" .Values.imagePullPolicy }}
+        imagePullSecrets:
+          {{- toYaml . | nindent 12 }}
         ports:
           - containerPort: 2020
         env:


### PR DESCRIPTION
Motivation:

Allow docker images to be pulled from a private docker registry e.g. artifactory