### PR TITLE
Updated RBAC resources from v1beta1 to v1

### DIFF
--- a/charts/humio-core/templates/post-install-role-binding.yaml
+++ b/charts/humio-core/templates/post-install-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}-post-install

--- a/charts/humio-core/templates/post-install-role.yaml
+++ b/charts/humio-core/templates/post-install-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-post-install

--- a/charts/humio-fluentbit/templates/fluent-bit-role-binding.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}-fluentbit-read

--- a/charts/humio-fluentbit/templates/fluent-bit-role.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-fluentbit-read

--- a/charts/humio-metrics/templates/metricbeat-cluster-role-binding.yaml
+++ b/charts/humio-metrics/templates/metricbeat-cluster-role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: metricbeat

--- a/charts/humio-metrics/templates/metricbeat-cluster-role.yaml
+++ b/charts/humio-metrics/templates/metricbeat-cluster-role.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metricbeat

--- a/charts/humio-strix/templates/strix-role-binding.yaml
+++ b/charts/humio-strix/templates/strix-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}-strix

--- a/charts/humio-strix/templates/strix-role.yaml
+++ b/charts/humio-strix/templates/strix-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-strix


### PR DESCRIPTION
The rbac.authorization.k8s.io/v1beta1 API version of ClusterRole and ClusterRoleBinding will no longer be served in Kubernetes v1.22, and has been deprecated since Kubernetes 1.17.

This PR updates RBAC resources from v1beta1 to v1.