### PR TITLE
Adds extraVolumes and extraVolumeMounts options to fluentbit

### DIFF
--- a/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
+++ b/charts/humio-fluentbit/templates/fluent-bit-ds.yaml
@@ -169,6 +169,11 @@ spec:
         {{- end }}
         - name: config
           mountPath: /fluent-bit/etc/
+        {{- if .Values.extraVolumeMounts }}
+        {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
         {{- with .Values.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
@@ -186,6 +191,11 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- end }}
       - name: config
         configMap:

--- a/charts/humio-fluentbit/values.yaml
+++ b/charts/humio-fluentbit/values.yaml
@@ -28,6 +28,9 @@ tokenSecretKeyName: token
 hecTokenSecretName: ""
 hecTokenSecretKeyName: token
 
+extraVolumes: {}
+extraVolumeMounts: {}
+
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
When using addition log sources from the host it's useful to be able to specify addition volumes and volume mounts.