### PR TITLE
added additional metricsets for the configmap

### DIFF
--- a/charts/humio-metrics/templates/metricbeat-deployment-modules-configmap.yaml
+++ b/charts/humio-metrics/templates/metricbeat-deployment-modules-configmap.yaml
@@ -17,6 +17,9 @@ data:
         - state_pod
         - state_container
         - event
+        {{- range .Values.additionMetricbeatMetricsets }}
+        - {{ .name }}
+        {{- end }}
       period: 10s
       host: ${NODE_NAME}
       hosts: ["{{ .Release.Name }}-kube-state-metrics.{{ default "kube-system" .Release.Namespace }}:8080"]


### PR DESCRIPTION
I wanted to add more metric sets to the configmap. I have added in a variable here and therefore you can add additional sets in the values.yaml when deploying. 
```
humio-metrics:
  humioHostname: cloud.humio.com
  token: REDACTED
  additionMetricbeatMetricsets:
  - name: state_daemonset
  - name: state_resourcequota
  enabled: true
  es:
    autodiscovery: false
    tls: true
```